### PR TITLE
Fix route collision: rename /login to /invite for frontend routes

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -9,7 +9,7 @@ server {
         autoindex off;
     }
 
-    location ~ ^/(login|protected|rsvp|guests|admin|mark-opened|comments|health|spotify) {
+    location ~ ^/(protected|rsvp|guests|admin|mark-opened|comments|health|spotify) {
         proxy_pass http://backend:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontend/src/api/axiosConfig.js
+++ b/frontend/src/api/axiosConfig.js
@@ -24,7 +24,7 @@ api.interceptors.response.use(
     if (error.response?.status === 401 && window.location.pathname !== '/') {
       // Handle unauthorized errors except on home page
       localStorage.removeItem('weddingToken');
-      window.location.href = '/login';
+      window.location.href = '/invite';
     }
     return Promise.reject(error);
   }

--- a/frontend/src/components/InvitationLanding.jsx
+++ b/frontend/src/components/InvitationLanding.jsx
@@ -263,7 +263,7 @@ function InvitationLanding() {
 
   useEffect(() => {
     if (!token || !currentUsername) {
-      navigate('/login');
+      navigate('/invite');
       return;
     }
 

--- a/frontend/src/components/LoginPage.jsx
+++ b/frontend/src/components/LoginPage.jsx
@@ -1,6 +1,6 @@
 import { Box, Typography, CircularProgress, Alert } from '@mui/material';
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuthContext } from '../contexts/AuthContext';
 import LanguageSwitcher from './LanguageSwitcher';
@@ -57,18 +57,15 @@ export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false);
 
   const navigate = useNavigate();
+  const { name } = useParams();
   const { login } = useAuthContext();
   const { t } = useTranslation();
 
   useEffect(() => {
-    const pathSegments = window.location.pathname.split('/');
-    const loginIndex = pathSegments.findIndex(segment => segment === 'login');
-    
-    if (loginIndex !== -1 && loginIndex < pathSegments.length - 1) {
-      const encodedName = pathSegments[loginIndex + 1];
+    if (name) {
       try {
-        const name = decodeURIComponent(encodedName);
-        handleAutoLogin(name);
+        const decodedName = decodeURIComponent(name);
+        handleAutoLogin(decodedName);
       } catch (error) {
         console.error('Error decoding name:', error);
         setError(t('login.invalidName'));
@@ -76,7 +73,7 @@ export default function LoginPage() {
     } else {
       setError(t('login.provideName'));
     }
-  }, []);
+  }, [name]);
 
   const handleAutoLogin = async (name) => {
     setIsLoading(true);

--- a/frontend/src/routes/Routes.jsx
+++ b/frontend/src/routes/Routes.jsx
@@ -9,8 +9,8 @@ import WeddingPhotoGallery from '../components/WeddingPhotoGallery';
 export default function AppRoutes() {
   return (
     <Routes>
-      <Route path="/login/:name" element={<LoginPage />} />
-      <Route path="/login/*" element={<LoginPage />} />
+      <Route path="/invite/:name" element={<LoginPage />} />
+      <Route path="/invite" element={<LoginPage />} />
       <Route path="/" element={<InvitationLanding />} />
       <Route path="/venue" element={<VenueMap />} />
       <Route path="/comments" element={<GuestComments />} />

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -19,8 +19,46 @@ export default defineConfig({
     host: true,
     open: true,
     watch: {
-      usePolling: true, // Needed for WSL2 filesystem watching
-      interval: 1000    // Poll every second
+      usePolling: true,
+      interval: 1000
+    },
+    proxy: {
+      '/login': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      },
+      '/protected': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      },
+      '/rsvp': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      },
+      '/guests': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      },
+      '/admin': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      },
+      '/mark-opened': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      },
+      '/comments': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      },
+      '/health': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      },
+      '/spotify': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      }
     }
   }
 })


### PR DESCRIPTION
- Frontend route /login/:name -> /invite/:name to avoid collision with backend API
- LoginPage.jsx: use useParams() hook for cleaner name extraction
- InvitationLanding.jsx: redirect to /invite instead of /login
- axiosConfig.js: redirect to /invite on 401 error
- nginx.conf: remove /login from proxy regex (backend keeps /login for API)
- vite.config.js: add dev server proxy for API routes