### PR TITLE
fix: pass string to submitComment instead of nested object

### DIFF
--- a/frontend/src/components/WishesPreview.jsx
+++ b/frontend/src/components/WishesPreview.jsx
@@ -113,7 +113,7 @@ export default function WishesPreview({ comments = [], navigate, username }) {
 
     setIsSubmitting(true);
     try {
-      const response = await submitComment({ content: message.trim() });
+      const response = await submitComment(message.trim());
       const newComment = {
         guest_name: username || 'Guest',
         content: message.trim(),


### PR DESCRIPTION
The API function already wraps the argument in { content }, so passing an object caused double-wrapping: { content: { content: "..." } }.

This caused the backend to reject the request with:
  json: cannot unmarshal object into Go struct field
  CreateCommentRequest.content of type string