### PR TITLE
fix: move nginx root directive to server level to serve static assets…

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,11 +1,12 @@
 # Gzip compression
 gzip on;
-gzip_types text/html text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 gzip_min_length 1000;
 
 server {
     listen 80;
     server_name localhost;
+    root /usr/share/nginx/html;
 
     # Cache static assets (1 year for hashed files)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
@@ -14,7 +15,6 @@ server {
     }
 
     location / {
-        root /usr/share/nginx/html;
         index index.html;
         try_files $uri $uri/ /index.html;
         autoindex off;


### PR DESCRIPTION
The root directive was only inside location / {}, so the regex location block for static assets (.js, .css, etc.) fell back to nginx's default /etc/nginx/html/ instead of /usr/share/nginx/html, causing 404s for all JS/CSS bundles. Also removed duplicate text/html from gzip_types.